### PR TITLE
CCDIMTP-384: update OpenPedCan Analyses version

### DIFF
--- a/front-end/assets/data/version.json
+++ b/front-end/assets/data/version.json
@@ -11,8 +11,7 @@
   },
   "openPedCanAnalyses": {
     "__comment": "OpenPedCan Analyses",
-    "version": "10",
-    "releaseDate": "2021-10-12"
+    "customVersion": "SomaticAlterations_v11.1; GeneExpression_v10"
   },
   "oncoKBCancerGeneList": {
     "__comment": "OncoKB Cancer Gene List",


### PR DESCRIPTION
In this PR:
- New field called `customVersion` is added under `version.json` to accommodate any version naming.
- Using `customVersion`, OpenPedCan Analyses version has been updated to `SomaticAlterations_v11.1; GeneExpression_v10`

Related Ticket: CCDIMTP-384